### PR TITLE
revert: 440de0c, use jar

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -2,24 +2,24 @@
 set -e
 VERSION="v3.18.2";
 curl -O -L https://dl.cryptlex.com/downloads/${VERSION}/LexActivator-Android.zip
-
 unzip LexActivator-Android.zip -d ./android
 cp ./android/libs/clang/arm64-v8a/libLexActivator.so lexactivator/src/main/jniLibs/arm64-v8a
 cp ./android/libs/clang/armeabi-v7a/libLexActivator.so lexactivator/src/main/jniLibs/armeabi-v7a
 rm LexActivator-Android.zip
 rm -r android
 
-# This is no longer required since JNA is imported with @aar directive.
-
-# curl -O -L https://github.com/java-native-access/jna/raw/master/lib/native/android-armv7.jar
-# curl -O -L https://github.com/java-native-access/jna/raw/master/lib/native/android-aarch64.jar
-# unzip android-aarch64.jar -d ./jni64
-# unzip android-armv7.jar -d ./jni
-# cp ./jni/libjnidispatch.so lexactivator/src/main/jniLibs/armeabi-v7a
-# cp ./jni64/libjnidispatch.so lexactivator/src/main/jniLibs/arm64-v8a
-# rm -f android-armv7.jar
-# rm -f android-aarch64.jar
+curl -O -L https://github.com/java-native-access/jna/raw/master/lib/native/android-armv7.jar
+curl -O -L https://github.com/java-native-access/jna/raw/master/lib/native/android-aarch64.jar
+unzip android-aarch64.jar -d ./jni64
+unzip android-armv7.jar -d ./jni
+cp ./jni/libjnidispatch.so lexactivator/src/main/jniLibs/armeabi-v7a
+cp ./jni64/libjnidispatch.so lexactivator/src/main/jniLibs/arm64-v8a
+rm -r jni jni64
+rm android-armv7.jar
+rm android-aarch64.jar
 
 # LibC++ from NDK in bundle.
 cp $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so lexactivator/src/main/jniLibs/arm64-v8a
 cp $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so lexactivator/src/main/jniLibs/armeabi-v7a
+
+

--- a/lexactivator/build.gradle
+++ b/lexactivator/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    implementation 'net.java.dev.jna:jna:5.11.0@aar'
+    implementation 'net.java.dev.jna:jna:5.11.0'
 }
 
 if (project.hasProperty("lexVersion")) {


### PR DESCRIPTION
Since Maven Central uses `pom.xml` for all package information, the @aar directive used in Gradle is lost and the import does not work as intended as it ends up importing the JAR dependency of JNA instead of the AAR.

Using the AAR dependency saved us the trouble of downloading libjnidispatch.so and packaging it but it will not be possible to run the application correctly as of yet with our package hosted on Maven Central.